### PR TITLE
fix: correctness batch from the 2026-06-10 audit (M1-M5, L1-L3)

### DIFF
--- a/src/neutron_geomcorr/geometry_correction.py
+++ b/src/neutron_geomcorr/geometry_correction.py
@@ -45,6 +45,15 @@ from numpy.typing import NDArray
 from tqdm.auto import tqdm
 
 
+def _is_integer(value: object) -> bool:
+    """True for Python and NumPy integers, False for booleans and the rest.
+
+    ``isinstance(value, int)`` alone would reject ``np.int64`` (the natural
+    output of ``argmax``/center-of-mass) and accept ``True``/``False``.
+    """
+    return isinstance(value, (int, np.integer)) and not isinstance(value, (bool, np.bool_))
+
+
 class GeometryCorrection:
     """
     Perform cylindrical geometry correction on neutron transmission images.
@@ -66,7 +75,9 @@ class GeometryCorrection:
     list_data : list of ndarray
         List of loaded image data arrays.
     list_data_corrected : list of ndarray
-        List of corrected image data arrays.
+        List of corrected image data arrays, each of shape
+        ``(height, 2*outer_radius - 1)`` (the x = ±outer_radius edge columns
+        are trimmed — zero chord length makes the correction undefined there).
     pixel_center : int
         Horizontal pixel position of the cylinder center.
     outer_radius : int
@@ -82,17 +93,6 @@ class GeometryCorrection:
     >>> gc.correct()
     """
 
-    list_data: Optional[List[NDArray[np.float64]]] = []
-    list_data_corrected: List[NDArray[np.float64]] = []
-
-    step1: bool = False  # load
-    step2: bool = False  # parameters definition
-
-    _outer_radius: float = np.nan
-    _inner_radius: float = np.nan
-    _pixel_center: int = 0
-    _list_files: List[str] = []
-
     def __init__(self, list_files: Optional[List[str]] = None) -> None:
         """
         Initialize the GeometryCorrection object.
@@ -103,7 +103,15 @@ class GeometryCorrection:
             List of file paths to neutron transmission images.
             Default is empty list.
         """
-        self.list_files = list_files
+        # per-instance state: class-level lists would be shared across instances
+        self.list_data: List[NDArray[np.float32]] = []
+        self.list_data_corrected: List[NDArray[np.float64]] = []
+        self.step1: bool = False  # load
+        self.step2: bool = False  # parameters definition
+        self._outer_radius: float = np.nan
+        self._inner_radius: float = np.nan
+        self._pixel_center: int = 0
+        self.list_files = list_files if list_files is not None else []
 
     def run(
         self,
@@ -145,9 +153,11 @@ class GeometryCorrection:
         --------
         >>> gc = GeometryCorrection(list_files=['sample.tif'])
         >>> gc.run(pixel_center=256, outer_radius=100)
+        >>> corrected_data = gc.list_data_corrected
         """
         self.load_files(notebook=notebook)
         self.define_parameters(pixel_center=pixel_center, outer_radius=outer_radius, inner_radius=inner_radius)
+        self.correct(notebook=notebook)
 
     @property
     def list_files(self) -> List[str]:
@@ -209,8 +219,9 @@ class GeometryCorrection:
         if self.step1 is False:
             raise AttributeError("Please define the list of files first by running the 'load_files' method!")
 
-        if not isinstance(pixel_center, int):
+        if not _is_integer(pixel_center):
             raise ValueError("Pixel center must be an integer!")
+        pixel_center = int(pixel_center)
 
         [_, width] = np.shape(self.list_data[0])
         if (pixel_center <= 0) or (pixel_center >= width):
@@ -236,11 +247,13 @@ class GeometryCorrection:
         Raises
         ------
         ValueError
-            If outer_radius is not a positive integer or defines cylinder
-            outside image bounds.
+            If outer_radius is not a positive integer, equals the already-set
+            inner_radius (zero wall thickness), or defines cylinder outside
+            image bounds.
         """
-        if not isinstance(outer_radius, int):
+        if not _is_integer(outer_radius):
             raise ValueError("Radius 1 must be an integer!")
+        outer_radius = int(outer_radius)
 
         if outer_radius <= 0:
             raise ValueError("Radius 1 must be greater than 0!")
@@ -251,6 +264,9 @@ class GeometryCorrection:
 
         if (self.pixel_center + outer_radius) >= width:
             raise ValueError("Cylinder defined by Radius 1 goes outside the image size (right side)!")
+
+        if self._inner_radius == outer_radius:
+            raise ValueError("Radius 1 and Radius 2 must be different (equal radii give a zero wall thickness)!")
 
         if np.isnan(self._inner_radius):
             self._outer_radius = outer_radius
@@ -278,11 +294,13 @@ class GeometryCorrection:
         Raises
         ------
         ValueError
-            If inner_radius is not a positive integer or defines cylinder
-            outside image bounds.
+            If inner_radius is not a positive integer, is set before
+            outer_radius, equals outer_radius (zero wall thickness), or
+            defines cylinder outside image bounds.
         """
-        if not isinstance(inner_radius, int):
+        if not _is_integer(inner_radius):
             raise ValueError("Radius 2 must be an integer!")
+        inner_radius = int(inner_radius)
 
         if inner_radius <= 0:
             raise ValueError("Radius 2 must be greater than 0!")
@@ -293,6 +311,14 @@ class GeometryCorrection:
 
         if (self.pixel_center + inner_radius) >= width:
             raise ValueError("Cylinder defined by Radius 2 goes outside the image size (right side)!")
+
+        if np.isnan(self._outer_radius):
+            # without this guard the swap below would store inner_radius as
+            # the OUTER radius and NaN as inner — silently a solid cylinder
+            raise ValueError("Please define outer_radius first!")
+
+        if inner_radius == self._outer_radius:
+            raise ValueError("Radius 1 and Radius 2 must be different (equal radii give a zero wall thickness)!")
 
         if self._outer_radius > inner_radius:
             self._inner_radius = inner_radius
@@ -314,9 +340,10 @@ class GeometryCorrection:
         Raises
         ------
         OSError
-            If a file has an unsupported extension (TIFF/FITS only), does
-            not contain a single 2D image after squeezing, or its shape
-            does not match the previously loaded images.
+            If list_files is empty, a file has an unsupported extension
+            (TIFF/FITS only), does not contain a single 2D image after
+            squeezing, or its shape does not match the previously loaded
+            images.
 
         Notes
         -----
@@ -330,6 +357,9 @@ class GeometryCorrection:
         The progress bar is a ``tqdm.auto`` bar: a widget inside Jupyter,
         a console bar elsewhere.
         """
+        if not self.list_files:
+            raise OSError("No image files to load: 'list_files' is empty!")
+
         list_data = []
         for _file in tqdm(self.list_files, desc="Loading", disable=not notebook, leave=False):
             _lower = str(_file).lower()
@@ -384,12 +414,14 @@ class GeometryCorrection:
         Notes
         -----
         For hollow cylinders, the method automatically ensures outer_radius > inner_radius
-        by swapping values if necessary.
+        by swapping values if necessary; equal radii are rejected (zero wall
+        thickness). After this method succeeds, sets step2 flag to True.
         """
         self.pixel_center = pixel_center
         self.outer_radius = outer_radius
         if not np.isnan(inner_radius):
             self.inner_radius = inner_radius
+        self.step2 = True
 
     def get_sample_thickness_at_center(self) -> float:
         """
@@ -471,7 +503,10 @@ class GeometryCorrection:
         Returns
         -------
         ndarray
-            Corrected 2D image array.
+            Corrected 2D image array of shape ``(height, 2*outer_radius - 1)``:
+            the cylinder region spans columns ``x`` in ``[-R, R]`` and the two
+            edge columns ``x = ±R`` are trimmed (zero chord length there makes
+            the correction undefined).
         """
         _image = self.isolate_cylinder_from_image(index=index)
 
@@ -486,7 +521,8 @@ class GeometryCorrection:
                 _corrected_value = (_intensity_of_pixel * _coeff) / 2.0
                 corrected_image[_slice_index, _index_pixel] = _corrected_value
 
-        # remove first pixel
+        # trim the two edge columns (x = ±outer_radius): the chord length is
+        # zero there, so the correction factor is undefined (NaN)
         corrected_image = corrected_image[:, 1:-1]
         absolute_radius = self.get_sample_thickness_at_center() / 2
 
@@ -502,13 +538,26 @@ class GeometryCorrection:
             Whether to display a progress bar (for Jupyter notebooks).
             Default is False.
 
+        Raises
+        ------
+        AttributeError
+            If load_files() has not been run, or the geometry parameters have
+            not been defined via define_parameters().
+
         Notes
         -----
-        Results are stored in the list_data_corrected attribute.
+        Results are stored in the list_data_corrected attribute. Each
+        corrected image has shape ``(height, 2*outer_radius - 1)`` — see
+        :meth:`_correct_file_index`.
 
         The progress bar is a ``tqdm.auto`` bar: a widget inside Jupyter,
         a console bar elsewhere.
         """
+        if self.step1 is False:
+            raise AttributeError("Please load the data first by running the 'load_files' method!")
+        if self.step2 is False:
+            raise AttributeError("Please define the geometry first by running the 'define_parameters' method!")
+
         self.list_data_corrected = []
         for _index in tqdm(range(len(self.list_data)), desc="Correcting", disable=not notebook, leave=False):
             self.list_data_corrected.append(self._correct_file_index(_index))
@@ -549,15 +598,22 @@ class GeometryCorrection:
         Returns
         -------
         float
-            Correction factor for solid cylinder at position x.
+            Correction factor for solid cylinder at position x: 0 outside the
+            cylinder (``|x| > radius``), NaN at the tangent edges
+            (``|x| == radius``, zero chord length), finite inside.
         """
-        if np.abs(x) > radius:
+        r = np.abs(x)
+        if r > radius:
             return 0
-        rp = 2 * radius * np.sin(np.arccos(x / radius))
+        if r == radius:
+            # zero chord length at the tangent edge: correction undefined.
+            # checking |x| instead of the chord value keeps the two edges
+            # symmetric — sin(arccos(-1.0)) is 1.2e-16, not 0, so the
+            # previous rp == 0 guard caught only the +radius edge
+            return np.nan
         if x == 0:
             return 1
-        if rp == 0:
-            return np.nan
+        rp = 2 * radius * np.sin(np.arccos(x / radius))
         return (2 * radius) / rp
 
     @staticmethod

--- a/src/neutron_geomcorr/geometry_correction.py
+++ b/src/neutron_geomcorr/geometry_correction.py
@@ -140,6 +140,9 @@ class GeometryCorrection:
 
         Raises
         ------
+        OSError
+            Propagated from load_files(): empty list_files, unsupported
+            file extension, non-2D image data, or mismatched image shapes.
         ValueError
             If pixel_center is not a positive integer within image bounds.
         ValueError

--- a/tests/test_geometry_correction.py
+++ b/tests/test_geometry_correction.py
@@ -265,12 +265,11 @@ class TestRun:
         o_cgc.load_files(notebook=True)
         assert len(o_cgc.list_data) == 1
 
-    def test_run_loads_and_defines_parameters(self, homogeneous_tiff_files):
-        """assert run() loads data and stores the geometry parameters
+    def test_run_loads_defines_parameters_and_corrects(self, homogeneous_tiff_files):
+        """assert run() performs the full load + define + correct pipeline
 
-        Characterization: run() currently does NOT apply the correction even
-        though its docstring says it does (tracked for the correctness PR);
-        this test pins what run() actually does today.
+        Previously run() silently skipped the correction step despite its
+        docstring; list_data_corrected stayed empty.
         """
         o_cgc = GeometryCorrection(list_files=homogeneous_tiff_files)
         o_cgc.run(pixel_center=256, outer_radius=200)
@@ -278,7 +277,117 @@ class TestRun:
         assert len(o_cgc.list_data) == len(homogeneous_tiff_files)
         assert o_cgc.pixel_center == 256
         assert o_cgc.outer_radius == 200
-        # run() does NOT apply the correction today; when the correctness fix
-        # makes run() call correct() (matching its docstring), this assertion
-        # must flip to assert the corrected data exists
-        assert o_cgc.list_data_corrected == []
+        assert len(o_cgc.list_data_corrected) == len(homogeneous_tiff_files)
+        assert o_cgc.list_data_corrected[0].shape == (512, 2 * 200 - 1)
+
+
+class TestValidation:
+    """Regression tests for the correctness batch (audit M2-M5, L1-L3)."""
+
+    def test_correct_requires_loaded_data(self, homogeneous_tiff_files):
+        """M5: correct() before load_files() must raise, not silently no-op"""
+        o_cgc = GeometryCorrection(list_files=homogeneous_tiff_files)
+        with pytest.raises(AttributeError, match="load_files"):
+            o_cgc.correct()
+
+    def test_correct_requires_defined_parameters(self, homogeneous_tiff_files):
+        """M5: correct() after load but before define_parameters() must raise
+        a descriptive error instead of an opaque TypeError from slicing"""
+        o_cgc = GeometryCorrection(list_files=homogeneous_tiff_files)
+        o_cgc.load_files()
+        with pytest.raises(AttributeError, match="define_parameters"):
+            o_cgc.correct()
+
+    def test_failed_define_parameters_does_not_unlock_correct(self, homogeneous_tiff_files):
+        """M5: a define_parameters() call that raises must leave correct() locked"""
+        o_cgc = GeometryCorrection(list_files=homogeneous_tiff_files)
+        o_cgc.load_files()
+        with pytest.raises(ValueError):
+            o_cgc.define_parameters(pixel_center=256, outer_radius=800)
+        with pytest.raises(AttributeError, match="define_parameters"):
+            o_cgc.correct()
+
+    def test_zero_wall_thickness_rejected(self, homogeneous_tiff_files):
+        """M3: inner_radius == outer_radius (zero wall) must raise instead of
+        producing NaN/inf garbage downstream"""
+        o_cgc = GeometryCorrection(list_files=homogeneous_tiff_files)
+        o_cgc.load_files()
+        with pytest.raises(ValueError, match="zero wall thickness"):
+            o_cgc.define_parameters(pixel_center=256, outer_radius=100, inner_radius=100)
+
+        # same guard on the outer_radius setter (hollow state already defined)
+        o_cgc = GeometryCorrection(list_files=homogeneous_tiff_files)
+        o_cgc.load_files()
+        o_cgc.define_parameters(pixel_center=256, outer_radius=120, inner_radius=100)
+        with pytest.raises(ValueError, match="zero wall thickness"):
+            o_cgc.outer_radius = 100
+
+    def test_inner_radius_requires_outer_radius_first(self, homogeneous_tiff_files):
+        """M4: setting inner_radius while outer_radius is unset previously
+        swap-assigned the value as the OUTER radius — silently a solid cylinder"""
+        o_cgc = GeometryCorrection(list_files=homogeneous_tiff_files)
+        o_cgc.load_files()
+        o_cgc.pixel_center = 256
+        with pytest.raises(ValueError, match="outer_radius first"):
+            o_cgc.inner_radius = 100
+        # the failed assignment must not have corrupted the geometry
+        assert np.isnan(o_cgc.outer_radius)
+        assert np.isnan(o_cgc.inner_radius)
+
+    def test_numpy_integers_accepted(self, homogeneous_tiff_files):
+        """L3: np.int64 (natural output of argmax/center-of-mass) must pass
+        the integer validation on all three geometry setters"""
+        o_cgc = GeometryCorrection(list_files=homogeneous_tiff_files)
+        o_cgc.load_files()
+        o_cgc.define_parameters(
+            pixel_center=np.int64(256),
+            outer_radius=np.int64(200),
+            inner_radius=np.int64(150),
+        )
+        assert o_cgc.pixel_center == 256
+        assert o_cgc.outer_radius == 200
+        assert o_cgc.inner_radius == 150
+
+    def test_booleans_rejected_as_integers(self, homogeneous_tiff_files):
+        """L3: True passes isinstance(_, int) but is not a valid pixel index"""
+        o_cgc = GeometryCorrection(list_files=homogeneous_tiff_files)
+        o_cgc.load_files()
+        with pytest.raises(ValueError, match="integer"):
+            o_cgc.define_parameters(pixel_center=True)
+
+    def test_empty_file_list_raises_on_load(self):
+        """L1: an empty list_files previously sailed through load_files() and
+        crashed later in define_parameters with an unrelated error"""
+        o_cgc = GeometryCorrection(list_files=[])
+        with pytest.raises(OSError, match="empty"):
+            o_cgc.load_files()
+
+    def test_default_constructor_works(self):
+        """L2: GeometryCorrection() previously raised TypeError despite the
+        documented 'Default is empty list'"""
+        o_cgc = GeometryCorrection()
+        assert o_cgc.list_files == []
+
+    def test_instances_do_not_share_state(self, homogeneous_tiff_files):
+        """M1 hazard: list_data/list_data_corrected were class-level lists
+        shared across instances"""
+        a = GeometryCorrection(list_files=homogeneous_tiff_files)
+        a.load_files()
+        b = GeometryCorrection()
+        assert b.list_data == []
+        assert b.list_data is not a.list_data
+        assert b.list_data_corrected is not a.list_data_corrected
+
+    def test_homogeneous_correction_edge_symmetry(self):
+        """M2: the correction factor must behave identically at both tangent
+        edges; sin(arccos(-1.0)) == 1.2e-16 previously made x=-R return a
+        finite 8e15 while x=+R returned NaN"""
+        assert np.isnan(GeometryCorrection.homogeneous_correction(x=200, radius=200))
+        assert np.isnan(GeometryCorrection.homogeneous_correction(x=-200, radius=200))
+        assert GeometryCorrection.homogeneous_correction(x=201, radius=200) == 0
+        assert GeometryCorrection.homogeneous_correction(x=-201, radius=200) == 0
+        assert GeometryCorrection.homogeneous_correction(x=0, radius=200) == 1
+        # interior values stay finite and mirror-symmetric
+        left = GeometryCorrection.homogeneous_correction(x=-199, radius=200)
+        right = GeometryCorrection.homogeneous_correction(x=199, radius=200)
+        assert np.isfinite(left) and left == pytest.approx(right)


### PR DESCRIPTION
## Summary

PR 3 of the audit-driven follow-up series (`audits/CylindricalGeometryCorrection_audit_2026-06-10.md`), resolving findings **M1–M5** and **L1–L3**. Behavior-only fixes; no API removals.

| ID | Fix |
|----|-----|
| M1 | `run()` now applies the correction as its docstring promises (previously `list_data_corrected` stayed empty; the characterization test pinning the old behavior is flipped) |
| M2 | `homogeneous_correction` returns NaN at **both** tangent edges — `sin(arccos(-1.0))` float noise previously made `x=-R` return a finite 8e15 while `x=+R` returned NaN; the `(H, 2R-1)` output geometry and edge-column trim are now documented in the docstrings |
| M3 | equal inner/outer radii (zero wall thickness) rejected by both radius setters instead of producing NaN/inf output |
| M4 | setting `inner_radius` before `outer_radius` raises `ValueError("Please define outer_radius first!")` instead of silently swap-assigning the value as the OUTER radius (solid-cylinder math on hollow-cylinder data) |
| M5 | `correct()` raises descriptive `AttributeError`s before `load_files()`/`define_parameters()`; the dead `step2` flag is now set and consumed |
| L1 | empty file list rejected up front in `load_files()` instead of crashing later inside `define_parameters` with an unrelated error |
| L2 | `GeometryCorrection()` default constructor works as documented |
| L3 | numpy integers (`np.int64` from `argmax` etc.) accepted by the geometry setters; booleans rejected |
| — | `list_data`/`list_data_corrected`/step flags moved from shared class-level attributes to per-instance state (hazard noted in M1) |

## Test plan

- 11 new regression tests in `TestValidation` + flipped `run()` characterization test
- `pixi run test`: **78 passed** (was 67)
- `pre-commit` clean on changed files

Remaining audit follow-ups land separately: PR 4 file_handler (M6/L4), PR 5 tooling quick wins, PR 6 packaging+security CI, PR 7 docs, PR 8 physics decision (H1, issue #57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)