### PR TITLE
ci: publish job needs the pixi binary; add manual-publish escape hatch

### DIFF
--- a/.github/workflows/manual-publish.yaml
+++ b/.github/workflows/manual-publish.yaml
@@ -1,0 +1,49 @@
+name: Manual conda publish
+
+# operational escape hatch: re-publish the conda artifact from a previous
+# "Package and Deployment" run (e.g. when the publish job failed after a
+# successful build, as on v2.0.0). The artifact is fetched cross-run, so the
+# package content is exactly what that run built and verified.
+on:
+  workflow_dispatch:
+    inputs:
+      run-id:
+        description: Run ID of the Package and Deployment run that built the artifact
+        required: true
+      label:
+        description: Anaconda channel label (main, rc, dev)
+        required: true
+        default: main
+
+permissions:
+  contents: read
+  actions: read # cross-run artifact download
+
+jobs:
+  publish:
+    name: Upload package to anaconda
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
+        with:
+          manifest-path: pyproject.toml
+          run-install: false
+
+      - name: Download conda package artifact from source run
+        uses: actions/download-artifact@v8
+        with:
+          name: artifact-conda-package
+          run-id: ${{ inputs.run-id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload package to anaconda
+        uses: neutrons/conda-actions/publish@bba9ca89d48d9ae846db9650cc63fde736340b3d # v2
+        with:
+          anaconda-token: ${{ secrets.ANACONDA_TOKEN }}
+          organization: neutronimaging
+          label: ${{ inputs.label }}
+          package-path: neutron-geomcorr-*.conda

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -94,14 +94,26 @@ jobs:
       # on a path that stays unexercised until then
       actions: read
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # the publish wrapper runs `pixi upload`, so the pixi binary must be on
+      # PATH (this is exactly what broke the v2.0.0 upload); the project env
+      # itself is not needed
+      - name: Setup pixi
+        uses: prefix-dev/setup-pixi@5185adfbffb4bd703da3010310260805d89ebb11 # v0.9.6
+        with:
+          manifest-path: pyproject.toml
+          run-install: false
+
       - name: Download conda package artifact
         uses: actions/download-artifact@v8
         with:
           name: artifact-conda-package
 
       # README documents `conda install -c neutronimaging neutron-geomcorr`;
-      # requires the ANACONDA_TOKEN repo secret (org decision: neutronimaging
-      # channel, not neutrons)
+      # requires the ANACONDA_TOKEN secret (org-level; org decision:
+      # neutronimaging channel, not neutrons)
       - name: Upload package to anaconda
         uses: neutrons/conda-actions/publish@bba9ca89d48d9ae846db9650cc63fde736340b3d # v2
         with:


### PR DESCRIPTION
## Summary

The v2.0.0 release pipeline ran end-to-end for the first time: tests green, conda build+verify+scan green, **PyPI trusted publishing succeeded** (neutron-geomcorr 2.0.0 is live) — but the **anaconda upload failed** with "pixi is not available": the `conda-actions/publish` wrapper runs `pixi upload`, and I had dropped the template's setup-pixi step when slimming the publish job. My miss.

Two changes:
1. **Fix**: the publish job gets checkout + setup-pixi (`run-install: false` — only the binary is needed).
2. **Recovery without re-tagging**: a `manual-publish` workflow (`workflow_dispatch`, inputs: source run-id + label) that downloads the conda artifact **from a previous run** and uploads it. The v2.0.0 artifact was built and verified in run 27368012833; re-tagging is the wrong tool (the tag's workflow snapshot is immutable, and PyPI would reject the duplicate 2.0.0). This also leaves a permanent ops escape hatch.

## After merge

1. Promote next→qa→main (keeps the fixed workflow on main for future tags)
2. Dispatch **Manual conda publish** with run-id `27368012833`, label `main` → puts `neutron-geomcorr 2.0.0` on the neutronimaging channel

## Test plan

- pre-commit clean; the publish-job fix mirrors the template's working pattern (checkout + setup-pixi precede the wrapper in every green template run)
- The manual workflow is exercised as the actual v2.0.0 recovery right after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)