### PR TITLE
fix(ci): switch conda-build to pixi publish + top up Grype ignores

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -48,8 +48,9 @@ jobs:
       - name: Build conda package
         run: |
           pixi run conda-build
-          mkdir -p /tmp/local-channel/linux-64
-          cp *.conda /tmp/local-channel/linux-64
+          # pixi publish writes the package into ./local-channel/<subdir>/;
+          # copy it to the workspace root for pkg-install and the artifact upload.
+          find local-channel -name "*.conda" -exec cp {} . \;
 
       # pkg-verify requires a conda env that already has the package
       # installed (and micromamba on PATH); pkg-install sets both up.
@@ -58,7 +59,7 @@ jobs:
         uses: neutrons/conda-actions/pkg-install@bba9ca89d48d9ae846db9650cc63fde736340b3d # v2
         with:
           package-name: ${{ env.PKG_NAME }}
-          local-channel: /tmp/local-channel
+          local-channel: ./local-channel
 
       - name: Verify conda package
         uses: neutrons/conda-actions/pkg-verify@bba9ca89d48d9ae846db9650cc63fde736340b3d # v2

--- a/.grype.yaml
+++ b/.grype.yaml
@@ -35,6 +35,12 @@ ignore:
   - vulnerability: CVE-2026-7774
     package:
       name: python
+  # Added 2026-07: the Grype vuln DB now flags this on cpython 3.14.6; the fix
+  # is only in the CPython 3.15.0b3 prerelease, with no stable 3.14 backport on
+  # conda-forge yet. Remove when a stable fix lands (lockfile-update picks it up).
+  - vulnerability: CVE-2026-12003
+    package:
+      name: python
 
   # Rust crates statically linked into transitively-pulled conda packages.
   # grype catalogs them from the compiled binaries, but CGC cannot remediate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,7 @@ pypi-publish = { cmd = "twine upload dist/*", description = "Publish the package
 pypi-publish-test = { cmd = "twine upload --repository testpypi dist/*", description = "Publish the package to TestPyPI", depends-on = [
   "pypi-build",
 ] }
-conda-build-command = { cmd = "pixi build", description = "Build the conda package command" }
+conda-build-command = { cmd = "pixi publish --target-channel ./local-channel", description = "Build the conda package into a local channel" }
 conda-build = { description = "Build the conda package", depends-on = [
   "backup-toml",
   "sync-version",


### PR DESCRIPTION
Two fixes so the **Build conda package** and **Grype** CI go green (both fail on #71):

1. **conda-build** — the `conda-build-command` task ran the deprecated `pixi build`, which errors on current pixi ("could not initialize the build-backend"). Switch to `pixi publish --target-channel ./local-channel` (the `neutrons/python_project_template` approach; the backend pin is already `*`). The package workflow now reads the built `.conda` from `./local-channel` instead of the old `/tmp/local-channel` copy.
2. **Grype** — the 2026-07 vuln DB flags `CVE-2026-12003` on `cpython 3.14.6` (fixed only in the 3.15.0b3 prerelease). Add a scoped `.grype.yaml` ignore with a revisit condition, matching the existing python block and timepix #87.

## Verification
Local (pixi 0.72.0): `pixi run conda-build` builds `local-channel/noarch/neutron-geomcorr-<gitversion>-*.conda`; `grype --fail-on medium --only-fixed dir:.pixi/envs/default` reports *No vulnerabilities found*. Once merged, the held bot PRs #71/#72/#73 can be updated and merged.

Assisted-With: Claude Opus 4.8 (1M context)